### PR TITLE
Version 1.2.0, 2020-06, Arithmetic circuits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+# Version 1.2.0, 2020-06, Arithmetic circuits
+
+Interface definition:
+- *(breaking)* Position of the field `ConstraintSystem.info` (unused afaik.).
+- Added `ConstraintSystem.constraint_type` to support for both R1CS and arithmetic circuits.
+
+Rust:
+- *(breaking)* New field `ConstraintSystemOwned.constraint_type`
+- A function to validate that a constraint system is indeed an arithmetic circuit (`validate_constraint_type`).
+
+
 # Version v1.1.1, 2020-06, libsnark and gadgetlib
 
 Interface definition:

--- a/examples/example.json
+++ b/examples/example.json
@@ -109,7 +109,8 @@
             ]
           }
         }
-      ]
+      ],
+      "constraint_type": "R1CS"
     }
   ],
   "witnesses": [

--- a/rust/src/examples.rs
+++ b/rust/src/examples.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::mem::size_of;
 use owned::circuit::CircuitOwned;
 use owned::variables::VariablesOwned;
-use zkinterface_generated::zkinterface::{BilinearConstraint, BilinearConstraintArgs, Message, ConstraintSystem, ConstraintSystemArgs, Root, RootArgs, Variables, VariablesArgs, Witness, WitnessArgs};
+use zkinterface_generated::zkinterface::{BilinearConstraint, BilinearConstraintArgs, Message, ConstraintSystem, ConstraintSystemArgs, Root, RootArgs, Variables, VariablesArgs, Witness, WitnessArgs, ConstraintType};
 
 
 pub fn example_circuit() -> CircuitOwned {
@@ -58,6 +58,7 @@ pub fn write_example_constraints<W: io::Write>(mut writer: W) -> io::Result<()> 
     let constraints_built = builder.create_vector(&constraints_built);
     let r1cs = ConstraintSystem::create(&mut builder, &ConstraintSystemArgs {
         constraints: Some(constraints_built),
+        constraint_type: ConstraintType::R1CS,
         info: None,
     });
 

--- a/rust/src/owned/constraints.rs
+++ b/rust/src/owned/constraints.rs
@@ -1,10 +1,12 @@
 use owned::variables::VariablesOwned;
 use serde::{Deserialize, Serialize};
-use zkinterface_generated::zkinterface::ConstraintSystem;
+use zkinterface_generated::zkinterface::{ConstraintSystem, ConstraintType};
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ConstraintSystemOwned {
     pub constraints: Vec<BilinearConstraintOwned>,
+
+    pub constraint_type: ConstraintTypeOwned,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -19,6 +21,7 @@ impl<'a> From<ConstraintSystem<'a>> for ConstraintSystemOwned {
     fn from(constraints_ref: ConstraintSystem) -> ConstraintSystemOwned {
         let mut owned = ConstraintSystemOwned {
             constraints: vec![],
+            constraint_type: constraints_ref.constraint_type().into(),
         };
 
         let cons_ref = constraints_ref.constraints().unwrap();
@@ -32,5 +35,32 @@ impl<'a> From<ConstraintSystem<'a>> for ConstraintSystemOwned {
         }
 
         owned
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[repr(i8)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum ConstraintTypeOwned {
+    R1CS = 0,
+    arithmetic = 1,
+}
+
+impl From<ConstraintType> for ConstraintTypeOwned {
+    fn from(ct: ConstraintType) -> Self {
+        match ct {
+            ConstraintType::R1CS => ConstraintTypeOwned::R1CS,
+            ConstraintType::arithmetic => ConstraintTypeOwned::arithmetic,
+        }
+    }
+}
+
+impl Into<ConstraintType> for ConstraintTypeOwned {
+    fn into(self) -> ConstraintType {
+        match self {
+            ConstraintTypeOwned::R1CS => ConstraintType::R1CS,
+            ConstraintTypeOwned::arithmetic => ConstraintType::arithmetic,
+        }
     }
 }

--- a/zkinterface.fbs
+++ b/zkinterface.fbs
@@ -44,11 +44,19 @@ table Circuit {
     configuration           :[KeyValue];
 }
 
+// A circuit can be R1CS or arithmetic (fan-in 2 multiplications).
+enum ConstraintType : byte { R1CS = 0, arithmetic = 1 }
+
 /// ConstraintSystem represents constraints to be added to the constraint system.
 ///
 /// Multiple such messages are equivalent to the concatenation of `constraints` arrays.
 table ConstraintSystem {
     constraints             :[BilinearConstraint];
+
+    /// Whether this is an R1CS or fan-in-2 arithmetic circuit.
+    /// A special case is a boolean circuit with XOR and AND gates,
+    /// then constraint_type == arithmetic and circuit.field_maximum == 1.
+    constraint_type            :ConstraintType;
 
     /// Optional: Any complementary info that may be useful.
     ///


### PR DESCRIPTION
# Version 1.2.0, 2020-06, Arithmetic circuits

Interface definition:
- *(breaking)* Position of the field `ConstraintSystem.info` (unused afaik.).
- Added `ConstraintSystem.constraint_type` to support for both R1CS and arithmetic circuits.

Rust:
- *(breaking)* New field `ConstraintSystemOwned.constraint_type`
- A function to validate that a constraint system is indeed an arithmetic circuit (`validate_constraint_type`).
