### PR TITLE
workspace: add export of constraints into multiple files instead of o…

### DIFF
--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -6,8 +6,8 @@ use std::io::{stdin, stdout, Read, Write, copy};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::{Reader, Workspace, Messages, consumers::stats::Stats, producers::workspace::clean_workspace, Result};
-use std::fs::{File, create_dir_all};
+use crate::{Reader, Workspace, Messages, consumers::stats::Stats, Result};
+use std::fs::{File, create_dir_all, remove_file};
 use std::ffi::OsStr;
 
 const ABOUT: &str = "
@@ -265,9 +265,16 @@ fn main_stats(ws: &Workspace) -> Result<()> {
 }
 
 fn main_clean(opts: &Options) -> Result<()> {
-    for path in &opts.paths {
-        clean_workspace(path)?;
+    let all_files = list_files(opts)?;
+    for file in &all_files {
+        match remove_file(file) {
+            Err(err) => {
+                eprintln!("Warning: {}", err)
+            }
+            _ => {/* OK */}
+        }
     }
+
     Ok(())
 }
 

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -267,6 +267,7 @@ fn main_stats(ws: &Workspace) -> Result<()> {
 fn main_clean(opts: &Options) -> Result<()> {
     let all_files = list_files(opts)?;
     for file in &all_files {
+        eprintln!("Removing {}", file.display());
         match remove_file(file) {
             Err(err) => {
                 eprintln!("Warning: {}", err)

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -6,7 +6,7 @@ use std::io::{stdin, stdout, Read, Write, copy};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::{Reader, Workspace, Messages, consumers::stats::Stats, Result};
+use crate::{Reader, Workspace, Messages, consumers::stats::Stats, producers::workspace::clean_workspace, Result};
 use std::fs::{File, create_dir_all};
 use std::ffi::OsStr;
 
@@ -67,6 +67,9 @@ pub struct Options {
     /// simulate    Simulate a proving system as prover by verifying that the statement is true.
     ///
     /// stats       Calculate statistics about the circuit.
+    ///
+    /// clean       Clean workspace by deleting all *.zkif files in it.
+    ///
     #[structopt(default_value = "help")]
     pub tool: String,
 
@@ -89,6 +92,7 @@ pub fn cli(options: &Options) -> Result<()> {
         "validate" => main_validate(&stream_messages(options)?),
         "simulate" => main_simulate(&stream_messages(options)?),
         "stats" => main_stats(&stream_messages(options)?),
+        "clean" => main_clean(options),
         "fake_prove" => main_fake_prove(&load_messages(options)?),
         "fake_verify" => main_fake_verify(&load_messages(options)?),
         "help" => {
@@ -257,6 +261,13 @@ fn main_stats(ws: &Workspace) -> Result<()> {
     stats.ingest_workspace(ws);
     serde_json::to_writer_pretty(stdout(), &stats)?;
     println!();
+    Ok(())
+}
+
+fn main_clean(opts: &Options) -> Result<()> {
+    for path in &opts.paths {
+        clean_workspace(path)?;
+    }
     Ok(())
 }
 

--- a/rust/src/producers/gadget_caller.rs
+++ b/rust/src/producers/gadget_caller.rs
@@ -33,11 +33,14 @@ impl<S: Sink + GadgetCallbacks> GadgetCallbacks for StatementBuilder<S> {
 }
 
 impl GadgetCallbacks for WorkspaceSink {
-    fn receive_constraints(&mut self, msg: &[u8]) -> Result<()> {
+    fn receive_constraints(&mut self, _msg: &[u8]) -> Result<()> {
+        unimplemented!();
+        /*
         if let Some(ref mut file) = self.constraints_file {
             file.write_all(msg)?;
         }
         Ok(())
+        */
     }
 
     fn receive_witness(&mut self, msg: &[u8]) -> Result<()> {

--- a/rust/src/producers/workspace.rs
+++ b/rust/src/producers/workspace.rs
@@ -44,11 +44,9 @@ impl Sink for WorkspaceSink {
     }
 
     fn push_constraints(&mut self, cs: ConstraintSystem) -> Result<()> {
-        let mut constraints_file = Some(File::create(
-                    self.workspace.join(format!("constraints_{}.zkif", &self.cs_file_counter)))?);
+        let mut constraints_file = File::create(self.workspace.join(format!("constraints_{}.zkif", &self.cs_file_counter)))?;
         self.cs_file_counter += 1;
-        let file = constraints_file.as_mut().unwrap();
-        cs.write_into(file)
+        cs.write_into(&mut constraints_file)
     }
 
     fn push_witness(&mut self, witness: Witness) -> Result<()> {

--- a/rust/src/producers/workspace.rs
+++ b/rust/src/producers/workspace.rs
@@ -1,21 +1,28 @@
 use std::path::{Path, PathBuf};
-use std::fs::{remove_file, File, create_dir_all};
+use std::fs::{remove_file, File, create_dir_all, read_dir};
+use std::ffi::OsStr;
 use crate::{Result, CircuitHeader, ConstraintSystem, Witness};
 use crate::producers::builder::Sink;
 
 pub fn clean_workspace(workspace: impl AsRef<Path>) -> Result<()> {
     let workspace = workspace.as_ref();
-    let _ = remove_file(workspace.join("header.zkif"));
-    let _ = remove_file(workspace.join("constraints.zkif"));
-    let _ = remove_file(workspace.join("witness.zkif"));
+
+    let files = read_dir(workspace)?;
+
+    for f in files.filter_map(std::result::Result::ok)
+        .filter(|d| d.path().extension() == Some(OsStr::new("zkif"))) {
+            remove_file(f.path())?;
+        }
+
     Ok(())
 }
+
 
 /// Store messages into files using conventional filenames inside of a workspace.
 pub struct WorkspaceSink {
     pub workspace: PathBuf,
-    pub constraints_file: Option<File>,
     pub witness_file: Option<File>,
+    cs_file_counter: u32,
 }
 
 impl WorkspaceSink {
@@ -23,8 +30,8 @@ impl WorkspaceSink {
         create_dir_all(workspace.as_ref())?;
         Ok(WorkspaceSink {
             workspace: workspace.as_ref().to_path_buf(),
-            constraints_file: None,
             witness_file: None,
+            cs_file_counter: 0,
         })
     }
 }
@@ -37,15 +44,10 @@ impl Sink for WorkspaceSink {
     }
 
     fn push_constraints(&mut self, cs: ConstraintSystem) -> Result<()> {
-        let file = match self.constraints_file {
-            None => {
-                self.constraints_file = Some(File::create(
-                    self.workspace.join("constraints.zkif"))?);
-                self.constraints_file.as_mut().unwrap()
-            }
-            Some(ref mut file) => file,
-        };
-
+        let mut constraints_file = Some(File::create(
+                    self.workspace.join(format!("constraints_{}.zkif", &self.cs_file_counter)))?);
+        self.cs_file_counter += 1;
+        let file = constraints_file.as_mut().unwrap();
         cs.write_into(file)
     }
 
@@ -61,4 +63,33 @@ impl Sink for WorkspaceSink {
 
         witness.write_into(file)
     }
+}
+
+
+#[test]
+fn test_workspace_cleanup() {
+    use std::fs::remove_dir_all;
+    use crate::producers::examples::example_constraints;
+
+    let workspace = PathBuf::from("local/test_workspace_cleanup");
+    let _ = remove_dir_all(&workspace);
+    let mut sink = WorkspaceSink::new(&workspace).unwrap();
+    
+    // workspace is empty, check it!
+    assert_eq!(read_dir(&workspace).unwrap().count(), 0);
+
+    // populate workspace
+    let cs1 = example_constraints();
+    sink.push_constraints(cs1).unwrap();
+    // ensure there is exactly one file created
+    assert_eq!(read_dir(&workspace).unwrap().count(), 1);
+
+    let cs2 = example_constraints();
+    sink.push_constraints(cs2).unwrap();
+    // ensure there is exactly two files created
+    assert_eq!(read_dir(&workspace).unwrap().count(), 2);
+
+    // clean workspace, and check there is no more file in it.
+    clean_workspace(&workspace).unwrap();
+    assert_eq!(read_dir(&workspace).unwrap().count(), 0);    
 }


### PR DESCRIPTION
…ne unique file +

clean_workspace() now removes all *.zkif files from workspace +
add "clean" options to CLI