### PR TITLE
Write the zkif "file identifier" to written files.

### DIFF
--- a/rust/src/structs/command.rs
+++ b/rust/src/structs/command.rs
@@ -68,7 +68,7 @@ impl Command {
     pub fn write_into(&self, writer: &mut impl Write) -> Result<()> {
         let mut builder = FlatBufferBuilder::new();
         let message = self.build(&mut builder);
-        builder.finish_size_prefixed(message, None);
+        fb::finish_size_prefixed_root_buffer(&mut builder, message);
         writer.write_all(builder.finished_data())?;
         Ok(())
     }

--- a/rust/src/structs/constraints.rs
+++ b/rust/src/structs/constraints.rs
@@ -148,7 +148,7 @@ impl ConstraintSystem {
     pub fn write_into(&self, writer: &mut impl Write) -> Result<()> {
         let mut builder = FlatBufferBuilder::new();
         let message = self.build(&mut builder);
-        builder.finish_size_prefixed(message, None);
+        fb::finish_size_prefixed_root_buffer(&mut builder, message);
         writer.write_all(builder.finished_data())?;
         Ok(())
     }

--- a/rust/src/structs/header.rs
+++ b/rust/src/structs/header.rs
@@ -140,7 +140,7 @@ impl CircuitHeader {
     pub fn write_into(&self, writer: &mut impl Write) -> Result<()> {
         let mut builder = FlatBufferBuilder::new();
         let message = self.build(&mut builder);
-        builder.finish_size_prefixed(message, None);
+        fb::finish_size_prefixed_root_buffer(&mut builder, message);
         writer.write_all(builder.finished_data())?;
         Ok(())
     }

--- a/rust/src/structs/witness.rs
+++ b/rust/src/structs/witness.rs
@@ -63,7 +63,7 @@ impl Witness {
     pub fn write_into(&self, writer: &mut impl Write) -> Result<()> {
         let mut builder = FlatBufferBuilder::new();
         let message = self.build(&mut builder);
-        builder.finish_size_prefixed(message, None);
+        fb::finish_size_prefixed_root_buffer(&mut builder, message);
         writer.write_all(builder.finished_data())?;
         Ok(())
     }


### PR DESCRIPTION
According to the `zkinterface.fbs` spec, the file type (magic-bytes) must be written to `zkif` files. Fix the code to reflect that.